### PR TITLE
edits from Guillaume

### DIFF
--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -202,16 +202,16 @@ def get_target_state_info(rgm_out_filename):
         raise ValueError("Parity value " + target_parity + " not understood")
     # I assume all hunks of relevant info look something like this:
     # J=  4    T=  2    Energy= -34.8845
-    regex = r'J=[ ]*-?[0-9]*[ ]*T=[ ]*-?[0-9]*[ ]*Energy=[ ]-?[0-9]*.?[0-9]*'
+    regex = r'J=[ ]*([.0-9]*)[ ]*T=[ ]*([.0-9]*)[ ]*Energy=[ ]*-?([.0-9]*).*'
     matches = re.findall(regex, text)
     states = []
     # keep a record of how many times a state with [J2, pi, T2] is entered
     nums = {}
     for match in matches:
-        words = match.split()
-        J2 = int(words[1])
-        T2 = int(words[3])
-        energy = float(words[5])
+        words = match
+        J2 = int(2.*float(words[0]))
+        T2 = int(2.*float(words[1]))
+        energy = float(words[2])
         num_string = f"{J2} {parity} {T2}"
         if num_string not in nums.keys():
             nums[num_string] = 1

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -245,8 +245,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                 if "0" not in transition_bank[(J2, p, T2)].keys():
                     transition_bank[(J2, p, T2)]["0"] = []
 
-                for i in range(1, num_desired_state+1):
-                    for j in range(1, num_desired_state+1):
+                for i in range(1, min(len(radii)+1,num_desired_state+1)):
+                    for j in range(1, min(len(radii)+1,num_desired_state+1)):
                         Rp, Rn, Rm = radii[(i, j)]
                         transition_bank[(J2, p, T2)]["0"].append(
                             (str(i), str(j), f"{Rp} {Rn} {Rm}"))


### PR DESCRIPTION
for cross_sections_utils.py
"
In the python, it is commented that:
 203     # I assume all hunks of relevant info look something like this:
 204     # J=  4    T=  2    Energy= -34.8845
while browsing the ncsm_rgm*.out. However the output is J = X.00YZ etc.. so I have modified the regexp to match this pattern. 
"

for ncsm_e1.py
 "
For the radii, the loop was running above the number (bounds) of radii read in the ncsd file. Typically it was running for all NCSMC compound eigenvalue of the J\piT of the bound state instead of running only for the eigenvalue corresponding to the bound state.

I have not derived the NCSMC <r_x> matrix element but I assume that you need the bound state ncsm contribution only. If not the problem is somewhere else namely the get_radii function does not read all the radii information contained in ncsd.out.
"