### PR TITLE
if observ doesn't contain the state then skip

### DIFF
--- a/cross_sections/file_tools.py
+++ b/cross_sections/file_tools.py
@@ -146,6 +146,9 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         _, J2, parity, T2, num, _, _ = state
         if "{} {} {}".format(J2, parity, T2) == desired_state:
             num_list.append(num)
+    if len(num_list)==0:
+        print("Desired state {} {} {}".format(J2, parity, T2), "not found in {}".format(filename))
+        return None, 0
     num_desired_state = max(num_list)
     # Now note that the Ex numbers in nuclei
     # are not exactly what's printed in the observ.out files.

--- a/cross_sections/file_tools.py
+++ b/cross_sections/file_tools.py
@@ -146,8 +146,9 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         _, J2, parity, T2, num, _, _ = state
         if "{} {} {}".format(J2, parity, T2) == desired_state:
             num_list.append(num)
-    if len(num_list)==0:
-        print("Desired state {} {} {}".format(J2, parity, T2), "not found in {}".format(filename))
+    if len(num_list) == 0:
+        print("Desired state {}".format(desired_state),
+              "not found in {}".format(filename))
         return None, 0
     num_desired_state = max(num_list)
     # Now note that the Ex numbers in nuclei

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -185,6 +185,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
             simp, num = file_tools.simplify_observ(
                 desired_state, transitions, filename, function="make_ncsm_e1")
             num_desired_state = num
+            if simp is None:
+                continue
             # get the useful info out of the data lines, e.g. E2p number
             # e.g. E1p in the line L= 1 E1p= -0.0102 E1n= 0.0102 B(E1)= 0.0001
             with open(simp, "r+") as simp_file:


### PR DESCRIPTION
 (should be in other observ file)

This is the version Petr is using in issue #3 ,sorry for not updating the main branch. I will continue developing to fix the new issues.

The initial issue was a crash when the 0+ was not found in the Jz=1 file (because it is in the Jz=0 file).