### PR TITLE
fix of KeyError in loop over radii (from GH)

### DIFF
--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -247,8 +247,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                 if "0" not in transition_bank[(J2, p, T2)].keys():
                     transition_bank[(J2, p, T2)]["0"] = []
 
-                for i in range(1, min(len(radii)+1,num_desired_state+1)):
-                    for j in range(1, min(len(radii)+1,num_desired_state+1)):
+                for i in range(1, min(len(radii)+1, num_desired_state+1)):
+                    for j in range(1, min(len(radii)+1, num_desired_state+1)):
                         Rp, Rn, Rm = radii[(i, j)]
                         transition_bank[(J2, p, T2)]["0"].append(
                             (str(i), str(j), f"{Rp} {Rn} {Rm}"))

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -247,8 +247,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                 if "0" not in transition_bank[(J2, p, T2)].keys():
                     transition_bank[(J2, p, T2)]["0"] = []
 
-                for i in range(1, num_desired_state+1):
-                    for j in range(1, num_desired_state+1):
+                for i in range(1, min(len(radii)+1,num_desired_state+1)):
+                    for j in range(1, min(len(radii)+1,num_desired_state+1)):
                         Rp, Rn, Rm = radii[(i, j)]
                         transition_bank[(J2, p, T2)]["0"].append(
                             (str(i), str(j), f"{Rp} {Rn} {Rm}"))


### PR DESCRIPTION
This fix should be added to master just to prevent the KeyError. Done by Guillaume in #1 

My understanding is that the radius values acquired from this loop are not currently used.
When calculating e.g. capture, the transition matrix elements of the radius operator are needed between bound and unbound states.
But these are found in the trdens outputs.
In the future, NPSM should get these values but this low-priority for now.