### PR TITLE
Modifications to the NCSM_E1 files

### DIFF
--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -225,13 +225,13 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
                 if (J2, parity_val, T2, i_num) not in states.keys():
                     states[(J2, parity_val, T2, i_num)] = E
                 elif abs(float(E)
-                       - float(states[(J2, parity_val, T2, i_num)])) > 1e-4:
+                        - float(states[(J2, parity_val, T2, i_num)])) > 1e-4:
                     if verbose:
                         print("duplicate state found, confused", line)
                         print(float(E)
-                            - float(states[(J2, parity_val, T2, i_num)]))
+                               - float(states[(J2, parity_val, T2, i_num)]))
                     raise RuntimeError("Found same state with different E",
-                                        line, E)
+                               line, E)
                 else:
                     if verbose:
                         print("duplicate state found, ignoring", line)

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -211,39 +211,41 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
         block = block.replace("\n ", "\n")
         block = block.replace("\n\n", "\n")
         lines = block.splitlines()
-        print(lines[:5])
-        print(lines[0])
-        print(lines[1])
-        print(lines[2])
+        #print(lines[:5])
+        #print(lines[0])
+        #print(lines[1])
+        #print(lines[2])
         words = lines[1].split()
-        print(words)
+        #print(words)
         # check if this is the right block for the resultant
         if int(words[1])==A:
-            print(lines[2])
+            #print(lines[2])
             # record parity
             parity = lines[2].split()[5]
             assert parity in ['-','+']
-            parity_dict = {'-':0, '+':1}
+            parity_dict = {'-':'-1', '+':'1'}
             parity_val = parity_dict[parity]
             i_num = 1
             for line in lines[5:]:
-                print(line)
+                #print(line)
                 if line=="":
                     break
                 _, J2, _, T2, _, E, _, Ex = line.split()
-                print(J2,T2,E,Ex)
+                #print(J2,T2,E,Ex)
                 if (J2, parity_val, T2, i_num) not in states.keys():
                     states[(J2, parity_val, T2, i_num)] = E
                 elif abs(float(E) - float(states[(J2, parity_val, T2, i_num)]))>1e-4:
-                    print("duplicate state found, confused",line)
-                    print(float(E) - float(states[(J2,parity_val,T2,i_num)]))
+                    if verbose:
+                        print("duplicate state found, confused",line)
+                        print(float(E) - float(states[(J2,parity_val,T2,i_num)]))
                     raise RuntimeError("Found same state with different energy",line,E)
                 else:
-                   print("duplicate state found, ignoring",line)
+                   if verbose:
+                       print("duplicate state found, ignoring",line)
                 i_num += 1
-            print(states)
+            if verbose: print(states)
         else:
-            print('no A match')
+            if verbose: print('no A match')
     return states
 
 

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -194,7 +194,6 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
                 break
     text = "\n".join(lines)
     blocks = text.split("Nucleus:")
-    #print(blocks[1])
     # Assume text looks like
     # '''
     #  Nucleus:
@@ -212,7 +211,7 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
         lines = block.splitlines()
         words = lines[1].split()
         # check if this is the right block for the resultant
-        if int(words[1])==A:
+        if int(words[1]) == A:
             # record parity
             parity = lines[2].split()[5]
             assert parity in ['-', '+']
@@ -225,14 +224,14 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
                 _, J2, _, T2, _, E, _, Ex = line.split()
                 if (J2, parity_val, T2, i_num) not in states.keys():
                     states[(J2, parity_val, T2, i_num)] = E
-                elif abs(float(E) - float(states[(J2, parity_val, T2, i_num)]))>1e-4:
+                elif abs(float(E) - float(states[(J2, parity_val, T2, i_num)])) > 1e-4:
                     if verbose:
                         print("duplicate state found, confused", line)
                         print(float(E) - float(states[(J2, parity_val, T2, i_num)]))
                     raise RuntimeError("Found same state with different energy", line, E)
                 else:
                     if verbose:
-                        print("duplicate state found, ignoring",line)
+                        print("duplicate state found, ignoring", line)
                 i_num += 1
             if verbose:
                 print(states)

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -176,7 +176,22 @@ def get_A_Z(name):
     Z = ptable[name[:n_chars]]
     return A, Z
 
+def get_all_resultant_states(rgm_out_filename, verbose=False):
+    if verbose:
+        print("getting resultant state list from", rgm_out_filename)
+    lines = []
+    with open(rgm_out_filename, "r+") as open_file:
+       for line in open_file:
+          if line!="  *** Composite nucleus ***":
+              lines.append(line)
+          else:
+              break
+    text = "\n".join(lines)
+    blocks = text.split(" NCSMC coupling kernels read from the file")
+    return None 
 
+
+# only bound states
 def get_resultant_state_info(rgm_out_filename, verbose=False):
     _, state_titles = simplify(rgm_out_filename, verbose=verbose)
     for i, title in enumerate(state_titles):

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -176,6 +176,7 @@ def get_A_Z(name):
     Z = ptable[name[:n_chars]]
     return A, Z
 
+
 def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
     if verbose:
         print("getting resultant state list from", rgm_out_filename)
@@ -183,11 +184,11 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
         print("Can't get resultant states because we don't know A")
         return None
     elif verbose:
-        print("Assuming nucleus with A=",A)
+        print("Assuming nucleus with A=", A)
     lines = []
     with open(rgm_out_filename, "r+") as open_file:
         for line in open_file:
-            if line!="  *** Composite nucleus ***\n":
+            if line != "  *** Composite nucleus ***\n":
                 lines.append(line)
             else:
                 break
@@ -214,29 +215,32 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
         if int(words[1])==A:
             # record parity
             parity = lines[2].split()[5]
-            assert parity in ['-','+']
-            parity_dict = {'-':'-1', '+':'1'}
+            assert parity in ['-', '+']
+            parity_dict = {'-': '-1', '+': '1'}
             parity_val = parity_dict[parity]
             i_num = 1
             for line in lines[5:]:
-                if line=="":
+                if line == "":
                     break
                 _, J2, _, T2, _, E, _, Ex = line.split()
                 if (J2, parity_val, T2, i_num) not in states.keys():
                     states[(J2, parity_val, T2, i_num)] = E
                 elif abs(float(E) - float(states[(J2, parity_val, T2, i_num)]))>1e-4:
                     if verbose:
-                        print("duplicate state found, confused",line)
-                        print(float(E) - float(states[(J2,parity_val,T2,i_num)]))
-                    raise RuntimeError("Found same state with different energy",line,E)
+                        print("duplicate state found, confused", line)
+                        print(float(E) - float(states[(J2, parity_val, T2, i_num)]))
+                    raise RuntimeError("Found same state with different energy", line, E)
                 else:
                     if verbose:
                         print("duplicate state found, ignoring",line)
                 i_num += 1
-            if verbose: print(states)
+            if verbose:
+                print(states)
         else:
-            if verbose: print('no A match')
+            if verbose:
+                print('no A match')
     return states
+
 
 # only bound states
 def get_resultant_state_info(rgm_out_filename, verbose=False):

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -192,7 +192,6 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
           else:
               break
     text = "\n".join(lines)
-    #print(text)
     blocks = text.split("Nucleus:")
     #print(blocks[1])
     # Assume text looks like
@@ -207,19 +206,12 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
     # '''
     states = {}
     for block in blocks[1:]:
-        #print(block)
         block = block.replace("\n ", "\n")
         block = block.replace("\n\n", "\n")
         lines = block.splitlines()
-        #print(lines[:5])
-        #print(lines[0])
-        #print(lines[1])
-        #print(lines[2])
         words = lines[1].split()
-        #print(words)
         # check if this is the right block for the resultant
         if int(words[1])==A:
-            #print(lines[2])
             # record parity
             parity = lines[2].split()[5]
             assert parity in ['-','+']
@@ -227,11 +219,9 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
             parity_val = parity_dict[parity]
             i_num = 1
             for line in lines[5:]:
-                #print(line)
                 if line=="":
                     break
                 _, J2, _, T2, _, E, _, Ex = line.split()
-                #print(J2,T2,E,Ex)
                 if (J2, parity_val, T2, i_num) not in states.keys():
                     states[(J2, parity_val, T2, i_num)] = E
                 elif abs(float(E) - float(states[(J2, parity_val, T2, i_num)]))>1e-4:
@@ -247,7 +237,6 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
         else:
             if verbose: print('no A match')
     return states
-
 
 # only bound states
 def get_resultant_state_info(rgm_out_filename, verbose=False):

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -208,32 +208,43 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
     states = {}
     for block in blocks[1:]:
         #print(block)
+        block = block.replace("\n ", "\n")
+        block = block.replace("\n\n", "\n")
         lines = block.splitlines()
+        print(lines[:5])
         print(lines[0])
         print(lines[1])
         print(lines[2])
-        words = lines[2].split()
+        words = lines[1].split()
         print(words)
         # check if this is the right block for the resultant
         if int(words[1])==A:
-            print(lines[5])
+            print(lines[2])
             # record parity
-            parity = lines[3].split()[5]
+            parity = lines[2].split()[5]
             assert parity in ['-','+']
             parity_dict = {'-':0, '+':1}
             parity_val = parity_dict[parity]
-            for line in lines[6:]:
-                if line=="\n":
+            i_num = 1
+            for line in lines[5:]:
+                print(line)
+                if line=="":
                     break
                 _, J2, _, T2, _, E, _, Ex = line.split()
-                if (J2, parity_val, T2) in states.keys():
-                    if 
+                print(J2,T2,E,Ex)
+                if (J2, parity_val, T2, i_num) not in states.keys():
+                    states[(J2, parity_val, T2, i_num)] = E
+                elif abs(float(E) - float(states[(J2, parity_val, T2, i_num)]))>1e-4:
+                    print("duplicate state found, confused",line)
+                    print(float(E) - float(states[(J2,parity_val,T2,i_num)]))
+                    raise RuntimeError("Found same state with different energy",line,E)
                 else:
-                    states[(J2,parity_val,T2)] = {}
-
+                   print("duplicate state found, ignoring",line)
+                i_num += 1
+            print(states)
         else:
             print('no A match')
-    return None 
+    return states
 
 
 # only bound states

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -186,11 +186,11 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
         print("Assuming nucleus with A=",A)
     lines = []
     with open(rgm_out_filename, "r+") as open_file:
-       for line in open_file:
-          if line!="  *** Composite nucleus ***\n":
-              lines.append(line)
-          else:
-              break
+        for line in open_file:
+            if line!="  *** Composite nucleus ***\n":
+                lines.append(line)
+            else:
+                break
     text = "\n".join(lines)
     blocks = text.split("Nucleus:")
     #print(blocks[1])
@@ -200,7 +200,7 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
     #  A=  8   Z=  4   N=  4
     #  2*MJ=  0   2*MT=  0  parity= +
     #  hbar Omega= 20.0000   Nhw= 12 nk= 15
-    #  
+    #
     #  2*J=  0    2*T=  0     Energy=    -52.3517     Ex=      0.0000
     #  ...
     # '''
@@ -230,8 +230,8 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
                         print(float(E) - float(states[(J2,parity_val,T2,i_num)]))
                     raise RuntimeError("Found same state with different energy",line,E)
                 else:
-                   if verbose:
-                       print("duplicate state found, ignoring",line)
+                    if verbose:
+                        print("duplicate state found, ignoring",line)
                 i_num += 1
             if verbose: print(states)
         else:

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -172,22 +172,67 @@ def get_A_Z(name):
     n_chars = 1
     while not is_float(name[n_chars:]):
         n_chars += 1
-    A = float(name[n_chars:])
+    A = int(name[n_chars:])
     Z = ptable[name[:n_chars]]
     return A, Z
 
-def get_all_resultant_states(rgm_out_filename, verbose=False):
+def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
     if verbose:
         print("getting resultant state list from", rgm_out_filename)
+    if A is None:
+        print("Can't get resultant states because we don't know A")
+        return None
+    elif verbose:
+        print("Assuming nucleus with A=",A)
     lines = []
     with open(rgm_out_filename, "r+") as open_file:
        for line in open_file:
-          if line!="  *** Composite nucleus ***":
+          if line!="  *** Composite nucleus ***\n":
               lines.append(line)
           else:
               break
     text = "\n".join(lines)
-    blocks = text.split(" NCSMC coupling kernels read from the file")
+    #print(text)
+    blocks = text.split("Nucleus:")
+    #print(blocks[1])
+    # Assume text looks like
+    # '''
+    #  Nucleus:
+    #  A=  8   Z=  4   N=  4
+    #  2*MJ=  0   2*MT=  0  parity= +
+    #  hbar Omega= 20.0000   Nhw= 12 nk= 15
+    #  
+    #  2*J=  0    2*T=  0     Energy=    -52.3517     Ex=      0.0000
+    #  ...
+    # '''
+    states = {}
+    for block in blocks[1:]:
+        #print(block)
+        lines = block.splitlines()
+        print(lines[0])
+        print(lines[1])
+        print(lines[2])
+        words = lines[2].split()
+        print(words)
+        # check if this is the right block for the resultant
+        if int(words[1])==A:
+            print(lines[5])
+            # record parity
+            parity = lines[3].split()[5]
+            assert parity in ['-','+']
+            parity_dict = {'-':0, '+':1}
+            parity_val = parity_dict[parity]
+            for line in lines[6:]:
+                if line=="\n":
+                    break
+                _, J2, _, T2, _, E, _, Ex = line.split()
+                if (J2, parity_val, T2) in states.keys():
+                    if 
+                else:
+                    states[(J2,parity_val,T2)] = {}
+
+        else:
+            print('no A match')
     return None 
 
 

--- a/cross_sections/cross_sections_utils.py
+++ b/cross_sections/cross_sections_utils.py
@@ -224,11 +224,14 @@ def get_all_resultant_states(rgm_out_filename, A=None, verbose=False):
                 _, J2, _, T2, _, E, _, Ex = line.split()
                 if (J2, parity_val, T2, i_num) not in states.keys():
                     states[(J2, parity_val, T2, i_num)] = E
-                elif abs(float(E) - float(states[(J2, parity_val, T2, i_num)])) > 1e-4:
+                elif abs(float(E)
+                       - float(states[(J2, parity_val, T2, i_num)])) > 1e-4:
                     if verbose:
                         print("duplicate state found, confused", line)
-                        print(float(E) - float(states[(J2, parity_val, T2, i_num)]))
-                    raise RuntimeError("Found same state with different energy", line, E)
+                        print(float(E)
+                            - float(states[(J2, parity_val, T2, i_num)]))
+                    raise RuntimeError("Found same state with different E",
+                                        line, E)
                 else:
                     if verbose:
                         print("duplicate state found, ignoring", line)

--- a/cross_sections/file_tools.py
+++ b/cross_sections/file_tools.py
@@ -130,7 +130,6 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         states = states[:n_states]
         nuclei.append(states)
         text = "\n".join(lines)
-        #print(text)
 
     assert len(nuclei) < 3  # let us pray this never fails
     # assuming all went well, now we have
@@ -273,14 +272,14 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         assert num == f_num
         new_name = "{} -- {} {} {} # {} {}".format(
             num, J2, f_parity, T2, state_counter[(J2, T2)], E)
-        print("replacing", title, "with", new_name)
+        if verbose: print("replacing", title, "with", new_name)
         text = text.replace(title, new_name)
 
     simp_path = filename+"_simp"
     if pn_mode: simp_path += "_pn"
     with open(simp_path, "w+") as simp_file:
         simp_file.write(text)
-    print('wrote output to', simp_path)
+    if verbose: print('wrote output to', simp_path)
 
     if function == "make_ncsm_e1":
         return simp_path, num_desired_state

--- a/cross_sections/file_tools.py
+++ b/cross_sections/file_tools.py
@@ -172,7 +172,7 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
     # take only data that is relevant to us
     # e.g. if we only have transitions = ["E3"] up top,
     # keep lines with E3 transitions and discard others
-    
+
     # we have data lines of the form:
 
     # #  4 [2*(J,T),Ex]_f=  5 1  7.5177   #  3 [2*(J,T),Ex]_i=  7 1  4.8240
@@ -203,12 +203,12 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         for i, line in enumerate(lines):
             if line[0] == "#":
                 state_line = line
-                print(state_line)
-                print(state_line[24])
+                #print(state_line)
+                #print(state_line[24])
                 if pn_mode: 
-                   state_line_list = list(state_line)
-                   state_line_list[24] = '0' # will break if either J,T are double digit
-                   state_line = ''.join(x for x in state_line_list)
+                    state_line_list = list(state_line)
+                    state_line_list[24] = '0' # TODO: will break if either J,T are double digit
+                    state_line = ''.join(x for x in state_line_list)
             #elif "#" in line:
             #    print('noop', line)
             elif line == line_to_find:

--- a/cross_sections/file_tools.py
+++ b/cross_sections/file_tools.py
@@ -5,6 +5,7 @@ import re
 from os.path import basename, join
 import cross_sections_utils
 
+
 def simplify_observ(desired_state, transitions, filename, function=None, verbose=True, pn_mode=False):
     """
     Makes a "simplified" version of an ``observ.out`` file.
@@ -33,7 +34,7 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
     """
     if verbose:
         print("simplifying", filename)
-        print("pn_mode=",pn_mode)
+        print("pn_mode=", pn_mode)
     # get all text from file
     with open(filename, "r+") as open_file:
         text = open_file.read()
@@ -110,7 +111,8 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
             J, T, E, Ex = list(map(float, [J, T, E, Ex]))
             J2 = round(J * 2)
             T2 = round(T * 2)
-            if pn_mode: T2 = 0 # ignore isospin and always set T=0
+            if pn_mode:
+                T2 = 0  # ignore isospin and always set T=0
             if (J2, T2) not in state_nums.keys():
                 state_nums[(J2, T2)] = 1
             else:
@@ -148,11 +150,9 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         _, J2, parity, T2, num, _, _ = state
         if "{} {} {}".format(J2, parity, T2) == desired_state:
             num_list.append(num)
-            print("Desired state {}".format(desired_state),
-                "found in {}".format(filename))
+            print(f"Desired state {desired_state} found in {filename}")
     if len(num_list) == 0:
-        print("Desired state {}".format(desired_state),
-              "not found in {}".format(filename))
+        print(f"Desired state {desired_state} not found in {filename}")
         return None, 0
     num_desired_state = max(num_list)
     # Now note that the Ex numbers in nuclei
@@ -203,17 +203,16 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         for i, line in enumerate(lines):
             if line[0] == "#":
                 state_line = line
-                #print(state_line)
-                #print(state_line[24])
+                # print(state_line)
+                # print(state_line[24])
                 if pn_mode: 
                     state_line_list = list(state_line)
-                    state_line_list[24] = '0' # TODO: will break if either J,T are double digit
+                    # TODO: will break if either J,T are double digit
+                    state_line_list[24] = '0'
                     state_line = ''.join(x for x in state_line_list)
-            #elif "#" in line:
-            #    print('noop', line)
             elif line == line_to_find:
                 interesting_lines += [state_line, m[1:], lines[i+1]]
-            #print(interesting_lines)
+            # print(interesting_lines)
     text = "\n".join(interesting_lines)
     
     # now we have something that looks mostly like this:
@@ -243,7 +242,8 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         _, num, _, J2, T2, Ex = title.split()
         num, J2, T2, Ex = list(map(float, [num, J2, T2, Ex]))
         num, J2, T2 = int(num), int(J2), int(T2)
-        if pn_mode: T2 = 0 # ignore isospin and always set T=0
+        if pn_mode:
+            T2 = 0  # ignore isospin and always set T=0
         if (J2, T2) not in state_counter.keys():
             state_counter[(J2, T2)] = 1
         else:
@@ -276,7 +276,8 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         text = text.replace(title, new_name)
 
     simp_path = filename+"_simp"
-    if pn_mode: simp_path += "_pn"
+    if pn_mode:
+        simp_path += "_pn"
     with open(simp_path, "w+") as simp_file:
         simp_file.write(text)
     if verbose: print('wrote output to', simp_path)

--- a/cross_sections/file_tools.py
+++ b/cross_sections/file_tools.py
@@ -205,7 +205,7 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
                 state_line = line
                 # print(state_line)
                 # print(state_line[24])
-                if pn_mode: 
+                if pn_mode:
                     state_line_list = list(state_line)
                     # TODO: will break if either J,T are double digit
                     state_line_list[24] = '0'
@@ -272,7 +272,8 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         assert num == f_num
         new_name = "{} -- {} {} {} # {} {}".format(
             num, J2, f_parity, T2, state_counter[(J2, T2)], E)
-        if verbose: print("replacing", title, "with", new_name)
+        if verbose:
+            print("replacing", title, "with", new_name)
         text = text.replace(title, new_name)
 
     simp_path = filename+"_simp"
@@ -280,7 +281,8 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         simp_path += "_pn"
     with open(simp_path, "w+") as simp_file:
         simp_file.write(text)
-    if verbose: print('wrote output to', simp_path)
+    if verbose:
+        print('wrote output to', simp_path)
 
     if function == "make_ncsm_e1":
         return simp_path, num_desired_state

--- a/cross_sections/file_tools.py
+++ b/cross_sections/file_tools.py
@@ -6,7 +6,8 @@ from os.path import basename, join
 import cross_sections_utils
 
 
-def simplify_observ(desired_state, transitions, filename, function=None, verbose=True, pn_mode=False):
+def simplify_observ(desired_state, transitions, filename, function=None,
+                    verbose=True, pn_mode=False):
     """
     Makes a "simplified" version of an ``observ.out`` file.
 

--- a/cross_sections/file_tools.py
+++ b/cross_sections/file_tools.py
@@ -149,6 +149,8 @@ def simplify_observ(desired_state, transitions, filename, function=None, verbose
         _, J2, parity, T2, num, _, _ = state
         if "{} {} {}".format(J2, parity, T2) == desired_state:
             num_list.append(num)
+            print("Desired state {}".format(desired_state),
+                "found in {}".format(filename))
     if len(num_list) == 0:
         print("Desired state {}".format(desired_state),
               "not found in {}".format(filename))

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -181,6 +181,19 @@ def make_ncsm_e1(desired_states, transitions, run_name,
        all_resultant_states = cross_sections_utils.get_all_resultant_states(ncsmc_rgm_out_file, A=A, verbose=verbose)
        # create mapping from ncsmc_rgm_out order to ascending energy
 
+        state_numbering = {}
+        for (J2, par, T2, i), E in all_resultant_states.items():
+            print(J2,par,T2,i,E)
+            if (J2, par, '0') not in state_numbering:
+                state_numbering[(J2, par, '0')] = []
+            state_numbering[(J2, par, '0')].append((float(E), i))
+        state_map = {}
+        for key, val in state_numbering.items():
+            print(key, val)
+            for iE, (E, istr) in enumerate(sorted(val)):
+                i = str(int(istr)-int(val[0][1])+1)
+                state_map[(key,str(iE+1))] = i
+        print(state_map)
 
     # make one ncsm_e1 file for each state
     for desired_state in desired_states:
@@ -254,13 +267,6 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                         if inum == i_num and fnum == f_num and params_are_same:
                             already_exists = True
                     if not already_exists:
-                        if pn_mode:
-                           fnum_max = 0
-                           for inum, fnum, _, _ in transition_bank[state_f_jpt][trans_type]:
-                              if inum == i_num:
-                                 if int(fnum) > fnum_max:
-                                    fnum_max = int(fnum)
-                           f_num = str(fnum_max+1)
                         transition_bank[state_f_jpt][trans_type].append(
                                 (i_num, f_num, param, M1_components[i+2]))
 
@@ -310,6 +316,10 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     block_lines = []
                     for transition in transition_bank[state_f][trans_type]:
                         i, f, param, comps = transition
+                        #print(transition[:2])
+                        if pn_mode:
+                            f = state_map[state_f,f]
+                            #print(i,f)
                         if i == i_val:
                             line_counter += 1
                             block_lines.append(" ".join([i, f, param]))

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -212,7 +212,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
         for file_index, filename in enumerate(observ_files):
             # simplify observ file
             simp, num = file_tools.simplify_observ(
-                desired_state, transitions, filename, function="make_ncsm_e1", pn_mode=pn_mode)
+                desired_state, transitions, filename,
+                function="make_ncsm_e1", pn_mode=pn_mode)
             num_desired_state = max(num, num_desired_state)
             if simp is None:
                 continue
@@ -299,8 +300,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     copy = transition_bank[state_f][trans_type]
                     for j, transition in enumerate(copy):
                         i, f, param, comps = transition
-                        f = state_map[state_f, f]
-                        transition_bank[state_f][trans_type][j] = (i, f, param, comps)
+                        new_f = state_map[state_f, f]
+                        transition_bank[state_f][trans_type][j] = (i, new_f, param, comps)
 
         # then go through and write all final states, in the format we need
         for state_f in sorted(transition_bank.keys()):
@@ -330,7 +331,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                             line_counter += 1
                             block_lines.append(" ".join([i, f, param]))
                             if comps is not None:
-                                block_lines[-1] = " ".join([block_lines[-1], " ".join(comps)])
+                                block_lines[-1] = " ".join([block_lines[-1],
+                                                           " ".join(comps)])
                     lines.append(str(line_counter))
                     lines += block_lines
         # once we've looped over all files, write data to a file for this state

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -244,13 +244,12 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                             already_exists = True
                     if not already_exists:
                         if pn_mode:
-                           fnum_pn = 0 # count number of duplicate states (only J pi)
-                           f_num_int = int(f_num)
+                           fnum_max = 0
                            for inum, fnum, _, _ in transition_bank[state_f_jpt][trans_type]:
-                              if inum == i_num and fnum == f_num:
-                                 fnum_pn += 1
-                                 f_num_int += fnum_pn
-                           f_num = str(f_num_int)
+                              if inum == i_num:
+                                 if int(fnum) > fnum_max:
+                                    fnum_max = int(fnum)
+                           f_num = str(fnum_max+1)
                         transition_bank[state_f_jpt][trans_type].append(
                                 (i_num, f_num, param, M1_components[i+2]))
 

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -10,6 +10,10 @@ import re
 desired_states = ["1 -1 3", "3 -1 3"]
 """resultant nucleus states we care about, 2J, pi, 2T"""
 
+pn_mode = True
+"""ignore isospin quantum numbers"""
+#(the transitions code will use proton and neutron components individually)
+
 transitions = ["E1", "E2", "M1"]
 """transitions we care about"""
 
@@ -221,6 +225,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     # ignore the bit at the start, and write state as a tuple
                     # which contains (2J, pi, 2T). Record state # too
                     state_f_jpt = tuple(state_f.split()[2:5])  # indices 2 3 4
+                    if pn_mode: state_f_jpt = tuple(state_f.split()[2:4])
                     # we'll only want transitions to final states of interest
                     f_num = state_f.split()[6]
                     # state_i_jpt = state_i.split()[2:5]
@@ -238,6 +243,14 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                         if inum == i_num and fnum == f_num and params_are_same:
                             already_exists = True
                     if not already_exists:
+                        if pn_mode:
+                           fnum_pn = 0 # count number of duplicate states (only J pi)
+                           f_num_int = int(f_num)
+                           for inum, fnum, _, _ in transition_bank[state_f_jpt][trans_type]:
+                              if inum == i_num and fnum == f_num:
+                                 fnum_pn += 1
+                                 f_num_int += fnum_pn
+                           f_num = str(f_num_int)
                         transition_bank[state_f_jpt][trans_type].append(
                                 (i_num, f_num, param, M1_components[i+2]))
 

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -13,7 +13,7 @@ desired_states = ["1 -1 3", "3 -1 3"]
 
 pn_mode = True
 """ignore isospin quantum numbers"""
-#(the transitions code will use proton and neutron components individually)
+# (the transitions code will use proton and neutron components individually)
 
 transitions = ["E1", "E2", "M1"]
 """transitions we care about"""
@@ -136,7 +136,8 @@ def get_radii(ncsd_file, nmax, state):
 
 
 def make_ncsm_e1(desired_states, transitions, run_name,
-                 observ_files, ncsd_file, nmax, out_dir=None, pn_mode=False, A=None, verbose=False):
+                 observ_files, ncsd_file, nmax, out_dir=None,
+                 pn_mode=False, A=None, verbose=False):
     """
     Makes NCSM_E1_Afi.dat files for the given parameters.
 
@@ -178,7 +179,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
 
     if pn_mode:
         # get order of states from ncsmc_rgm_out file
-        all_resultant_states = cross_sections_utils.get_all_resultant_states(ncsmc_rgm_out_file, A=A, verbose=verbose)
+        all_resultant_states = cross_sections_utils.get_all_resultant_states(
+              ncsmc_rgm_out_file, A=A, verbose=verbose)
         # create mapping from ncsmc_rgm_out order to ascending energy
         state_numbering = {}
         for (J2, par, T2, i), E in all_resultant_states.items():
@@ -211,7 +213,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
             # simplify observ file
             simp, num = file_tools.simplify_observ(
                 desired_state, transitions, filename, function="make_ncsm_e1", pn_mode=pn_mode)
-            num_desired_state = max(num,num_desired_state)
+            num_desired_state = max(num, num_desired_state)
             if simp is None:
                 continue
             # get the useful info out of the data lines, e.g. E2p number
@@ -326,8 +328,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                         if i == i_val:
                             line_counter += 1
                             block_lines.append(" ".join([i, f, param]))
-                            if not comps is None:
-                                block_lines[-1] = " ".join([block_lines[-1]," ".join(comps)])
+                            if comps is not None:
+                                block_lines[-1] = " ".join([block_lines[-1], " ".join(comps)])
                     lines.append(str(line_counter))
                     lines += block_lines
         # once we've looped over all files, write data to a file for this state

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -6,6 +6,7 @@ import file_tools
 import dot_in
 import os
 import re
+import cross_sections_utils
 
 desired_states = ["1 -1 3", "3 -1 3"]
 """resultant nucleus states we care about, 2J, pi, 2T"""
@@ -32,6 +33,7 @@ ncsd_file = "/home/callum/ncsd/Li9_n3lo-NN3Nlnl-srg2.0_Nmax8.20"
 
 nmax = 8
 
+A, _ = cross_sections_utils.get_A_Z("Be8")
 ncsmc_rgm_out_file = join(ncsmc_out_dir, f"ncsm_rgm_Am2_1_1.out_{run_name}")
 
 def transition_parameter(trans_str):
@@ -134,7 +136,7 @@ def get_radii(ncsd_file, nmax, state):
 
 
 def make_ncsm_e1(desired_states, transitions, run_name,
-                 observ_files, ncsd_file, nmax, out_dir=None, verbose=False):
+                 observ_files, ncsd_file, nmax, out_dir=None, pn_mode=False, A=None, verbose=False):
     """
     Makes NCSM_E1_Afi.dat files for the given parameters.
 
@@ -176,7 +178,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
 
     if pn_mode:
        # get order of states from ncsmc_rgm_out file
-       all_resultant_states = cross_sections_utils.get_all_resultant_states(ncsmc_rgm_out_file, verbose=verbose)
+       all_resultant_states = cross_sections_utils.get_all_resultant_states(ncsmc_rgm_out_file, A=A, verbose=verbose)
        # create mapping from ncsmc_rgm_out order to ascending energy
 
 
@@ -329,4 +331,4 @@ def make_ncsm_e1(desired_states, transitions, run_name,
 if __name__ == "__main__":
     make_ncsm_e1(
         desired_states, transitions, run_name, observ_files, ncsd_file, nmax,
-        out_dir="")
+        out_dir="", pn_mode=pn_mode, A=A, verbose=True)

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -193,7 +193,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
             # print(key, val)
             for iE, (E, istr) in enumerate(sorted(val)):
                 i = str(int(istr)-int(val[0][1])+1)
-                state_map[(key,str(iE+1))] = i
+                state_map[(key, str(iE+1))] = i
         # print(state_map)
 
     # make one ncsm_e1 file for each state
@@ -234,10 +234,10 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                             print(line)
                             raise ValueError("Could not find variable "+var)
                         lines[i] = words[index+1]
-                    if line=="M1":
+                    if line == "M1":
                         if lines[i+1][0:2] == "pl":
                             M1_components[i+1] = (lines[i+1].split()[1:8:2])
- 
+
             text = "\n".join(lines)
 
             # get transitions from simplified observ.out file
@@ -299,7 +299,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     copy = transition_bank[state_f][trans_type]
                     for j, transition in enumerate(copy):
                         i, f, param, comps = transition
-                        f = state_map[state_f,f]
+                        f = state_map[state_f, f]
                         transition_bank[state_f][trans_type][j] = (i, f, param, comps)
 
         # then go through and write all final states, in the format we need
@@ -323,7 +323,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     line_counter = 0
                     block_lines = []
                     # sort transitions by f so that the output comes out in the right order
-                    for transition in sorted(transition_bank[state_f][trans_type], key=lambda x:x[1]):
+                    for transition in sorted(transition_bank[state_f][trans_type],
+                                             key=lambda x: x[1]):
                         i, f, param, comps = transition
                         if i == i_val:
                             line_counter += 1

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -235,7 +235,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     if line=="M1":
                         if lines[i+1][0:2] == "pl":
                             M1_components[i+1] = (lines[i+1].split()[1:8:2])
-                     
+ 
             text = "\n".join(lines)
 
             # get transitions from simplified observ.out file
@@ -243,7 +243,6 @@ def make_ncsm_e1(desired_states, transitions, run_name,
             for i, line in enumerate(lines):
                 # get all transitions from the state of interest to others
                 if " ++ " + desired_state in line:
-                    
                     state_f, state_i = line.split("   ")  # 3 spaces
                     # ignore the bit at the start, and write state as a tuple
                     # which contains (2J, pi, 2T). Record state # too
@@ -297,9 +296,9 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                 for trans_type in sorted(transition_bank[state_f].keys()):
                     copy = transition_bank[state_f][trans_type]
                     for j, transition in enumerate(copy):
-                       i, f, param, comps = transition
-                       f = state_map[state_f,f]
-                       transition_bank[state_f][trans_type][j] = (i, f, param, comps)
+                        i, f, param, comps = transition
+                        f = state_map[state_f,f]
+                        transition_bank[state_f][trans_type][j] = (i, f, param, comps)
 
         # then go through and write all final states, in the format we need
         for state_f in sorted(transition_bank.keys()):

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -294,6 +294,15 @@ def make_ncsm_e1(desired_states, transitions, run_name,
         # first 2 lines of the file should be initial state description
         lines.append(desired_state)
         lines.append(str(num_desired_state))
+        if pn_mode:
+            for state_f in sorted(transition_bank.keys()):
+                for trans_type in sorted(transition_bank[state_f].keys()):
+                    copy = transition_bank[state_f][trans_type]
+                    for j, transition in enumerate(copy):
+                       i, f, param, comps = transition
+                       f = state_map[state_f,f]
+                       transition_bank[state_f][trans_type][j] = (i, f, param, comps)
+
         # then go through and write all final states, in the format we need
         for state_f in sorted(transition_bank.keys()):
             for trans_type in sorted(transition_bank[state_f].keys()):
@@ -314,12 +323,8 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     # line for how many lines are in this block
                     line_counter = 0
                     block_lines = []
-                    for transition in transition_bank[state_f][trans_type]:
+                    for transition in sorted(transition_bank[state_f][trans_type], key=lambda x:x[1]):
                         i, f, param, comps = transition
-                        #print(transition[:2])
-                        if pn_mode:
-                            f = state_map[state_f,f]
-                            #print(i,f)
                         if i == i_val:
                             line_counter += 1
                             block_lines.append(" ".join([i, f, param]))

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -188,7 +188,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
             # simplify observ file
             simp, num = file_tools.simplify_observ(
                 desired_state, transitions, filename, function="make_ncsm_e1", pn_mode=pn_mode)
-            num_desired_state = num
+            num_desired_state = max(num,num_desired_state)
             if simp is None:
                 continue
             # get the useful info out of the data lines, e.g. E2p number

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -33,7 +33,7 @@ ncsd_file = "/home/callum/ncsd/Li9_n3lo-NN3Nlnl-srg2.0_Nmax8.20"
 
 nmax = 8
 
-A, _ = cross_sections_utils.get_A_Z("Be8")
+A, _ = cross_sections_utils.get_A_Z("Li8")
 ncsmc_rgm_out_file = join(ncsmc_out_dir, f"ncsm_rgm_Am2_1_1.out_{run_name}")
 
 def transition_parameter(trans_str):
@@ -177,23 +177,22 @@ def make_ncsm_e1(desired_states, transitions, run_name,
     transition_bank = {}
 
     if pn_mode:
-       # get order of states from ncsmc_rgm_out file
-       all_resultant_states = cross_sections_utils.get_all_resultant_states(ncsmc_rgm_out_file, A=A, verbose=verbose)
-       # create mapping from ncsmc_rgm_out order to ascending energy
-
+        # get order of states from ncsmc_rgm_out file
+        all_resultant_states = cross_sections_utils.get_all_resultant_states(ncsmc_rgm_out_file, A=A, verbose=verbose)
+        # create mapping from ncsmc_rgm_out order to ascending energy
         state_numbering = {}
         for (J2, par, T2, i), E in all_resultant_states.items():
-            print(J2,par,T2,i,E)
+            # print(J2,par,T2,i,E)
             if (J2, par, '0') not in state_numbering:
                 state_numbering[(J2, par, '0')] = []
             state_numbering[(J2, par, '0')].append((float(E), i))
         state_map = {}
         for key, val in state_numbering.items():
-            print(key, val)
+            # print(key, val)
             for iE, (E, istr) in enumerate(sorted(val)):
                 i = str(int(istr)-int(val[0][1])+1)
                 state_map[(key,str(iE+1))] = i
-        print(state_map)
+        # print(state_map)
 
     # make one ncsm_e1 file for each state
     for desired_state in desired_states:
@@ -249,7 +248,6 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     # ignore the bit at the start, and write state as a tuple
                     # which contains (2J, pi, 2T). Record state # too
                     state_f_jpt = tuple(state_f.split()[2:5])  # indices 2 3 4
-                    #if pn_mode: state_f_jpt = tuple(state_f.split()[2:4])
                     # we'll only want transitions to final states of interest
                     f_num = state_f.split()[6]
                     # state_i_jpt = state_i.split()[2:5]
@@ -323,6 +321,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     # line for how many lines are in this block
                     line_counter = 0
                     block_lines = []
+                    # sort transitions by f so that the output comes out in the right order
                     for transition in sorted(transition_bank[state_f][trans_type], key=lambda x:x[1]):
                         i, f, param, comps = transition
                         if i == i_val:

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -32,6 +32,8 @@ ncsd_file = "/home/callum/ncsd/Li9_n3lo-NN3Nlnl-srg2.0_Nmax8.20"
 
 nmax = 8
 
+ncsmc_rgm_out_file = join(ncsmc_out_dir, f"ncsm_rgm_Am2_1_1.out_{run_name}")
+
 def transition_parameter(trans_str):
     """
     Which parameter should we take from lines of data?
@@ -171,6 +173,12 @@ def make_ncsm_e1(desired_states, transitions, run_name,
     # tolerance is controled by tol here:
     tol = 1e-3
     transition_bank = {}
+
+    if pn_mode:
+       # get order of states from ncsmc_rgm_out file
+       all_resultant_states = cross_sections_utils.get_all_resultant_states(ncsmc_rgm_out_file, verbose=verbose)
+       # create mapping from ncsmc_rgm_out order to ascending energy
+
 
     # make one ncsm_e1 file for each state
     for desired_state in desired_states:

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -184,6 +184,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
         j2_parity = J2 + ("m" if p == "-1" else "p")
         # data stores info from observ files, to be written out after the loop
         data = []
+        num_desired_state = 0
         for file_index, filename in enumerate(observ_files):
             # simplify observ file
             simp, num = file_tools.simplify_observ(

--- a/cross_sections/ncsm_e1.py
+++ b/cross_sections/ncsm_e1.py
@@ -187,7 +187,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
         for file_index, filename in enumerate(observ_files):
             # simplify observ file
             simp, num = file_tools.simplify_observ(
-                desired_state, transitions, filename, function="make_ncsm_e1")
+                desired_state, transitions, filename, function="make_ncsm_e1", pn_mode=pn_mode)
             num_desired_state = num
             if simp is None:
                 continue
@@ -225,7 +225,7 @@ def make_ncsm_e1(desired_states, transitions, run_name,
                     # ignore the bit at the start, and write state as a tuple
                     # which contains (2J, pi, 2T). Record state # too
                     state_f_jpt = tuple(state_f.split()[2:5])  # indices 2 3 4
-                    if pn_mode: state_f_jpt = tuple(state_f.split()[2:4])
+                    #if pn_mode: state_f_jpt = tuple(state_f.split()[2:4])
                     # we'll only want transitions to final states of interest
                     f_num = state_f.split()[6]
                     # state_i_jpt = state_i.split()[2:5]


### PR DESCRIPTION
I've added the components of the M1 operators (pl,nl,ps,ns) making the NCSM_E1 file consistent with the transitions_ncsmc.in file (the first is the A-body NCSM transitions, the second is the A-a (and a?)). This is useful as radiative capture involving some beyond standard model particles uses operators equivalent to the M1-spin components.

In addition, some versions of NCSMC ignore isospin (treating everything in proton/neutron components). In this case (pn_mode=True) the NCSM_E1 file is rearranged so that transitions between states [2J pi 2T] 0 1 0 - 2 1 2 are placed in the same block as 0 1 0 - 2 1 0 for example.

The remaining problem is that the current method sorts the states according to energy but the NCSMC kernels are arranged in blocks of isospin and then energy within the blocks (i.e. 2 1 2 goes after 2 1 0 even if the energy is lower). I'll leave this as a draft until this is solved.